### PR TITLE
added script context doc control decorator to ensure sc.doc is correctly set to Rhino.RhinoDoc.ActiveDoc

### DIFF
--- a/src/compas_rv2/rhino/helpers.py
+++ b/src/compas_rv2/rhino/helpers.py
@@ -7,6 +7,7 @@ import json
 from ast import literal_eval
 
 import scriptcontext as sc
+import Rhino
 
 import compas_rhino
 from compas_rhino.forms import TextForm
@@ -30,6 +31,16 @@ __all__ = [
     "select_faces",
     "rv2_undo"
 ]
+
+
+def set_scriptcontext_doc_to_rhino():
+    sc.doc = Rhino.RhinoDoc.ActiveDoc
+
+def scriptcontext_doc_control(func):
+    def wrapper(*args, **kwargs):
+        set_scriptcontext_doc_to_rhino()
+        return func(*args, **kwargs)
+    return wrapper
 
 
 def match_vertices(diagram, keys):
@@ -159,7 +170,7 @@ def get_rv2():
         return None
     return sc.sticky["RV2"]
 
-
+@scriptcontext_doc_control
 def get_scene():
     rv2 = get_rv2()
     if rv2:
@@ -258,6 +269,7 @@ def undo(sender, e):
 
 
 def rv2_undo(command):
+    @@scriptcontext_doc_control
     def wrapper(*args, **kwargs):
         sc.doc.EndUndoRecord(sc.doc.CurrentUndoRecordSerialNumber)
         undoRecord = sc.doc.BeginUndoRecord("RV2 Undo")


### PR DESCRIPTION
For those developing RV2-based plugins that are simultaneously operating with, and integrating both **IronPython** and **Grasshopper Python** (in cases featuring GH components that are actively running in the background), the **sc.doc** will be switched automatically by Rhinoceros from **Rhino.RhinoDoc.ActiveDoc** (the doc toolbar-based plugins like RV and RGS rely on) to **GHDoc**.  When this happens... **everything relying on sc.doc in compas_rhino will fail**--from the _management of undos_ to the _selection of objects_.

The work-in-progress-fix proposed here adds a function decorator to **get_scene** and **rv2_undo** to ensure that the proper scriptcontext doc is set before a toolbar-based function relying on sc.doc is executed.  The author has tested this, and confirms that it has resolved the most commonly encountered auto-doc-switching issues.