### PR TITLE
add release candidate options to invoke

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,21 @@ current_version = 1.1.9
 message = Bump version to {new_version}
 commit = True
 tag = True
+parse = ^
+	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)   # minimum 'N.N'
+	(?:
+	(?P<release>rc)
+	(?:(?P<rc>\d+(?:\.\d+)*))?
+	)?
+serialize = 
+	{major}.{minor}.{patch}{release}{rc}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = final
+values = 
+	rc
+	final
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,4 +22,4 @@ exclude pytest.ini .bumpversion.cfg .editorconfig
 exclude tasks.py
 exclude CONTRIBUTING.md
 
-global-exclude *.py[cod] __pycache__ *.dylib *.nb[ic] .DS_Store Thumbs.db
+global-exclude *.py[cod] __pycache__ *.dylib *.nb[ic] .DS_Store Thumbs.db *.rui_bak

--- a/tasks.py
+++ b/tasks.py
@@ -171,17 +171,26 @@ def prepare_changelog(ctx):
 
 
 @task(help={
-      'release_type': 'Type of release follows semver rules. Must be one of: major, minor, patch.'})
+      'release_type': 'Type of release follows semver rules. Must be one of: major, minor, patch, major-rc, minor-rc, patch-rc, rc, release.'})
 def release(ctx, release_type):
     """Releases the project in one swift command!"""
-    if release_type not in ('patch', 'minor', 'major'):
-        raise Exit('The release type parameter is invalid.\nMust be one of: major, minor, patch')
+    if release_type not in ('patch', 'minor', 'major', 'major-rc', 'minor-rc', 'patch-rc', 'rc', 'release'):
+        raise Exit('The release type parameter is invalid.\nMust be one of: major, minor, patch, major-rc, minor-rc, patch-rc, rc, release')
+
+    is_rc = release_type.find('rc') >= 0
+    release_type = release_type.split('-')[0]
 
     # Run checks
     ctx.run('invoke check')
 
     # Bump version and git tag it
-    ctx.run('bump2version %s --verbose' % release_type)
+    if is_rc:
+        ctx.run('bump2version %s --verbose' % release_type)
+    elif release_type == 'release':
+        ctx.run('bump2version release --verbose')
+    else:
+        ctx.run('bump2version %s --verbose --no-tag' % release_type)
+        ctx.run('bump2version release --verbose')
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This turned out quite tricky with limitation of bump2versions..... But this is the closet I can get it to. An example would be:
- Scenario A (release candidates):
`Invoke release patch-rc`  1.1.9 => 1.1.10rc0
`Invoke release rc`  1.1.10rc0 => 1.1.10rc1
`Invoke release rc`  1.1.10rc1 => 1.1.10rc2
`Invoke release release`  1.1.10rc2 => 1.1.10

- Scenario B (like before):
`Invoke release patch`  1.1.9 => 1.1.10


### Behind the scene

`.bumpversion.cfg` is setup to always append rc0 when a new version is incremented, then the `rc0` postfix can be either incremented by `bump2version rc` or removed by calling `bump2version release` which means a final release.
Below is the equivalent operations when using bump2version directly:
- Scenario A:
`bump2version patch`  1.1.9 => 1.1.10rc0
`bump2version rc`  1.1.10rc0 => 1.1.10rc1
`bump2version rc`  1.1.10rc1 => 1.1.10rc2
`bump2version release`  1.1.10rc2 => 1.1.10

- Scenario B:
`bump2version patch`  1.1.9 => 1.1.10rc0 + `bump2version release`  1.1.10rc0 => 1.1.10
