### PR TITLE
use `plugable` to indicate installable rhino packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* use `plugable` to indicate installable rhino packages
 
 ### Removed
 

--- a/src/compas_rv2/__init__.py
+++ b/src/compas_rv2/__init__.py
@@ -34,5 +34,5 @@ DATA = os.path.abspath(os.path.join(HOME, 'data'))
 DOCS = os.path.abspath(os.path.join(HOME, 'docs'))
 TEMP = os.path.abspath(os.path.join(HOME, 'temp'))
 
-
+__all_plugins__ = ['compas_rv2.install']
 # __all__ = ['HOME', 'DATA', 'DOCS', 'TEMP']

--- a/src/compas_rv2/install.py
+++ b/src/compas_rv2/install.py
@@ -16,6 +16,9 @@ from subprocess import call
 PLUGIN_NAME = "RV2"
 PACKAGES = ['compas', 'compas_rhino', 'compas_tna', 'compas_cloud', 'compas_skeleton', 'compas_rv2']
 
+@compas.plugins.plugin(category='install', pluggable_name='installable_rhino_packages', tryfirst=True)
+def default_installable_rhino_packages():
+    return PACKAGES
 
 def is_editable(project_name):
     """Is distribution an editable install?"""
@@ -86,7 +89,7 @@ if __name__ == '__main__':
     print("CONDA_DEFAULT_ENV", os.environ.get("CONDA_DEFAULT_ENV"))
     print("CONDA_EXE", os.environ.get("CONDA_EXE"))
 
-    install(packages=PACKAGES, version=args.rhino_version)
+    install(version=args.rhino_version)
 
     if compas.WINDOWS:
         call(sys.executable + " " + os.path.join(plugin_path, 'dev', 'rui.py'), shell=True)

--- a/src/compas_rv2/install.py
+++ b/src/compas_rv2/install.py
@@ -16,9 +16,11 @@ from subprocess import call
 PLUGIN_NAME = "RV2"
 PACKAGES = ['compas', 'compas_rhino', 'compas_tna', 'compas_cloud', 'compas_skeleton', 'compas_rv2']
 
+
 @compas.plugins.plugin(category='install', pluggable_name='installable_rhino_packages', tryfirst=True)
 def default_installable_rhino_packages():
     return PACKAGES
+
 
 def is_editable(project_name):
     """Is distribution an editable install?"""


### PR DESCRIPTION
Additionally we can also use `@compas.plugins.plugin(category='install')
def after_rhino_install(installed_packages):` for handling installation of UI component. However the downside currently is that after_rhino_install function is not aware of the rhino version. Can we add that at some point?